### PR TITLE
Include `OSTYPE=$OSTYPE` in prompt

### DIFF
--- a/ai.sh
+++ b/ai.sh
@@ -53,8 +53,12 @@ parse_cli() {
   user_input="$1"
 }
 
-openai_prompt_template=$(cat <<'EOF'
+# We include OSTYPE so that the model knows to recommend commands that work for that environment.
+# @see https://github.com/backus/ai.sh/pull/4
+openai_prompt_template=$(cat <<EOF
 # zsh
+#
+# OSTYPE=$OSTYPE
 #
 # All code that deletes, kills, or does an unrevertable update should be
 # prefixed with a comment saying "# destructive"


### PR DESCRIPTION
Helps the AI know to recommend environment specific commands.

## Examples

Without any hint, it varies (worst of both worlds):

```sh
$ ai 'copy foo/bar.txt to the clipboard'
# => cat foo/bar.txt | pbcopy

$ ai 'open file.pdf'
# => xdg-open file.pdf

$ ai 'setup a DNS server on 8.8.8.8'
# => # destructive
sudo echo "nameserver 8.8.8.8" > /etc/resolv.conf
```

With the hint (macOS):

```sh
$ ai 'copy foo/bar.txt to the clipboard'
# => cat foo/bar.txt | pbcopy

$ ai 'open file.pdf'
# => open file.pdf

$ ai 'setup a DNS server on 8.8.8.8'
# => # destructive
networksetup -setdnsservers Wi-Fi 8.8.8.8
```

With the hint (Linux):

```sh
$ ai 'copy foo/bar.txt to the clipboard'
# => cat foo/bar.txt | xclip -selection clipboard

$ ai 'open file.pdf'
# => xdg-open file.pdf

$ ai 'setup a DNS server on 8.8.8.8'
# => # destructive
sudo echo "nameserver 8.8.8.8" > /etc/resolv.conf
```